### PR TITLE
fixed deprecated loadImageSvg Raylib linking error.

### DIFF
--- a/scripts/raylib.json
+++ b/scripts/raylib.json
@@ -6670,25 +6670,6 @@
       ]
     },
     {
-      "name": "LoadImageSvg",
-      "description": "Load image from SVG file data or string with specified size",
-      "returnType": "Image",
-      "params": [
-        {
-          "type": "const char *",
-          "name": "fileNameOrString"
-        },
-        {
-          "type": "int",
-          "name": "width"
-        },
-        {
-          "type": "int",
-          "name": "height"
-        }
-      ]
-    },
-    {
       "name": "LoadImageAnim",
       "description": "Load image sequence from file (frames appended to image.data)",
       "returnType": "Image",

--- a/scripts/raylib_api.json
+++ b/scripts/raylib_api.json
@@ -6670,25 +6670,6 @@
       ]
     },
     {
-      "name": "LoadImageSvg",
-      "description": "Load image from SVG file data or string with specified size",
-      "returnType": "Image",
-      "params": [
-        {
-          "type": "const char *",
-          "name": "fileNameOrString"
-        },
-        {
-          "type": "int",
-          "name": "width"
-        },
-        {
-          "type": "int",
-          "name": "height"
-        }
-      ]
-    },
-    {
       "name": "LoadImageAnim",
       "description": "Load image sequence from file (frames appended to image.data)",
       "returnType": "Image",

--- a/src/raylib.adb
+++ b/src/raylib.adb
@@ -331,15 +331,6 @@ package body Raylib is
       return Result;
    end LoadImageRaw;
 
-   function LoadImageSvg (fileNameOrString : String; width : Interfaces.C.int; height : Interfaces.C.int) return Image is
-      use Interfaces.C.Strings;
-      C_fileNameOrString : Interfaces.C.Strings.chars_ptr := New_String (fileNameOrString);
-      Result : constant Image := LoadImageSvg (C_fileNameOrString, width, height);
-   begin
-      Free (C_fileNameOrString);
-      return Result;
-   end LoadImageSvg;
-
    function LoadImageAnim (fileName : String; frames : access Interfaces.C.int) return Image is
       use Interfaces.C.Strings;
       C_fileName : Interfaces.C.Strings.chars_ptr := New_String (fileName);

--- a/src/raylib.ads
+++ b/src/raylib.ads
@@ -2111,13 +2111,6 @@ is
    function LoadImageRaw (fileName : String; width : Interfaces.C.int; height : Interfaces.C.int; format : PixelFormat; headerSize : Interfaces.C.int) return Image;
    --  Load image from RAW file data
 
-   function LoadImageSvg (fileNameOrString : Interfaces.C.Strings.chars_ptr; width : Interfaces.C.int; height : Interfaces.C.int) return Image;
-   --  Load image from SVG file data or string with specified size
-   pragma Import (C, LoadImageSvg, "LoadImageSvg");
-
-   function LoadImageSvg (fileNameOrString : String; width : Interfaces.C.int; height : Interfaces.C.int) return Image;
-   --  Load image from SVG file data or string with specified size
-
    function LoadImageAnim (fileName : Interfaces.C.Strings.chars_ptr; frames : access Interfaces.C.int) return Image;
    --  Load image sequence from file (frames appended to image.data)
    pragma Import (C, LoadImageAnim, "LoadImageAnim");


### PR DESCRIPTION
Raylib loadImageSvg is depreacted in raylib 5.5. Checked raylib 5.5 and there is no longer a loadImageSvg function. Removed all refrences to it in raylib-ada binding generator. Just trying to help and not sure if i missed something. Hope this helps save some time. This should fix issue #3 