### PR TITLE
change type of parameter of 'SetConfigFlags' from Interfaces.C.Unsign…

### DIFF
--- a/src/raylib.ads
+++ b/src/raylib.ads
@@ -1412,7 +1412,7 @@ is
    procedure TakeScreenshot (fileName : String);
    --  Takes a screenshot of current screen (filename extension defines format)
 
-   procedure SetConfigFlags (flags : Interfaces.C.unsigned);
+   procedure SetConfigFlags (flags : ConfigFlags);
    --  Setup init configuration flags (view FLAGS)
    pragma Import (C, SetConfigFlags, "SetConfigFlags");
 


### PR DESCRIPTION
i found this repository and it seems to be just what i need but i got a compilation error with "SetConfigFlags(FLAG_WINDOW_RESIZABLE)" and noticed there was already a distinct type defined for these constants but SetConfigFlags expected a generic Interfaces.C.Unsigned